### PR TITLE
docs: generate mdbook docs

### DIFF
--- a/docs/book.nix
+++ b/docs/book.nix
@@ -1,0 +1,35 @@
+{ pkgs, ...}:
+let
+  author    = "nixosbrasil";
+  edit-path = "${org-url}/${project}/edit/master/docs/{path}";
+  org-url   = "https://github.com/${author}";
+  project   = "climod";
+
+  # Workaroud to fix infinity recursion
+  fake-mod  = pkgs.writeText "climodmod.nix"
+    (builtins.replaceStrings
+      ["        options = command;"]
+      [''options.name = mkOption { type = str; default = "..."; description = "This is a recursive from command"; };'']
+      (builtins.readFile ../modules/common.nix));
+in
+{
+  files.mdbook.authors      = ["NixOS Brasil <${org-url}>"];
+  files.mdbook.enable       = true;
+  files.mdbook.gh-author    = author;
+  files.mdbook.gh-project   = project;
+  files.mdbook.language     = "en";
+  files.mdbook.multilingual = false;
+  files.mdbook.summary      = builtins.readFile ./summary.md;
+  files.mdbook.title        = "Modular Generated Command Line Interfaces";
+  files.mdbook.output.html.fold.enable = true;
+  files.mdbook.output.html.edit-url-template   = edit-path;
+  files.mdbook.output.html.git-repository-icon = "fa-github";
+  files.mdbook.output.html.git-repository-url  = "${org-url}/${project}";
+  files.mdbook.output.html.no-section-label    = true;
+  files.mdbook.output.html.site-url            = "/${project}/";
+  files.text."/gh-pages/src/about.md" = builtins.readFile ../README.md;
+  files.docs."/gh-pages/src/options.md".modules = [
+    "${fake-mod}"
+    ../modules/bash/default.nix
+  ];
+}

--- a/docs/options.nix
+++ b/docs/options.nix
@@ -1,0 +1,25 @@
+{ pkgs, ...}:
+let
+  url = "https://github.com/nixosbrasil/climod";
+  src =  builtins.fetchGit {
+    inherit url;
+    rev = "b756461071cbbb105e7913e743795c09337e45b6";
+    ref = "master";
+  };
+  pkg = pkgs.writeText "climodmod.nix"
+    (builtins.replaceStrings
+      ["        options = command;"]
+      [''options.name = mkOption { type = str; default = "..."; description = "This is a recursive from command"; };'']
+      (builtins.readFile "${src}/modules/common.nix"));
+in
+{
+  files.docs."/docs/src/climod.md".modules = [
+    "${pkg}"
+    "${src}/modules/bash/default.nix"
+  ];
+  files.mdbook.summary = ''
+    ---
+    - [Climod](./climod.md)
+  '';
+  about.sources = "- [Climod](${url})";
+}

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [About](./about.md)
+- [Usage](./options.md)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,90 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": [
+          "dsf",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "dsf",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1663445644,
+        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "dsf": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1664593457,
+        "narHash": "sha256-eRgB8qfGYdAC+8Uli3AHv6i7O7rfnPXjVferyVORMoA=",
+        "owner": "cruel-intentions",
+        "repo": "devshell-files",
+        "rev": "99a20a99581da03af1adc70ab3236b96a778ad3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cruel-intentions",
+        "repo": "devshell-files",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1653936696,
+        "narHash": "sha256-M6bJShji9AIDZ7Kh7CPwPBPb/T7RiVev2PAcOi4fxDQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ce6aa13369b667ac2542593170993504932eb836",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dsf": "dsf",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,11 @@
+{
+  description = "Dev Environment";
+
+  inputs.nixpkgs.url  = "github:nixos/nixpkgs/22.05";
+  inputs.dsf.url      = "github:cruel-intentions/devshell-files";
+  inputs.dsf.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs = inputs: inputs.dsf.lib.shell inputs [
+    ./docs/book.nix
+  ];
+}

--- a/gh-pages/mdbook.toml
+++ b/gh-pages/mdbook.toml
@@ -1,0 +1,16 @@
+[book]
+authors = ["NixOS Brasil <https://github.com/nixosbrasil>"]
+language = "en"
+title = "Modular Generated Command Line Interfaces"
+
+[output]
+
+[output.html]
+edit-url-template = "https://github.com/nixosbrasil/climod/edit/master/docs/{path}"
+git-repository-icon = "fa-github"
+git-repository-url = "https://github.com/nixosbrasil/climod"
+no-section-label = true
+site-url = "/climod/"
+
+[output.html.fold]
+enable = true

--- a/gh-pages/src/SUMMARY.md
+++ b/gh-pages/src/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [About](./about.md)
+- [Usage](./options.md)

--- a/gh-pages/src/about.md
+++ b/gh-pages/src/about.md
@@ -1,0 +1,25 @@
+# climod
+
+[![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)
+
+ Modular generated command line interfaces using the same technology as the NixOS module system.
+
+## Objective
+What if you could generate CLI scripts with keyword parsing and environment variables with value validation and so on using a JSON like interface, but turing complete...
+
+Or even generate consistent CLIs for more than one programming language... (WIP, only bash atm).
+
+Maybe integrate in your own repo or automations.
+
+With this library and Nix now you can. See the [example](./example.nix) to get more details about how. If you nix-build it then it should generate a script on ./result that you can play with.
+
+
+# What works
+- Generation of bash scripts
+    - Flag parsing
+    - Subcommands
+    - Prelude (setup code before anything but `set -eu` and shebang)
+    - Your payload code just consume environment variables
+    - Positional arguments. All input values are flag based so far.
+# What doesn't work
+    - List of things. Each flag can only be provided once.

--- a/gh-pages/src/options.md
+++ b/gh-pages/src/options.md
@@ -1,0 +1,280 @@
+## action
+
+Attr of the action code itself of the command or subcommand for each language that you want to support
+
+#### type
+
+attribute set of string
+
+
+#### default
+
+```nix
+{
+  action = {
+    bash = "exit 0";
+    c = "exit(0);";
+  };
+}
+```
+
+
+## allowExtraArguments
+
+Allow the command to receive unmatched arguments
+
+#### type
+
+boolean
+
+
+#### default
+
+```nix
+{
+  allowExtraArguments = false;
+}
+```
+
+
+## description
+
+Command description
+
+#### type
+
+string
+
+
+#### default
+
+```nix
+{
+  description = "Example cli script generated with nix";
+}
+```
+
+
+## flags
+
+Command flags
+
+#### type
+
+list of submodule
+
+
+#### default
+
+```nix
+{
+  flags = [];
+}
+```
+
+
+## flags.*.description
+
+Description of the flag value
+
+#### type
+
+string
+
+
+#### default
+
+```nix
+{
+  flags.*.description = "";
+}
+```
+
+
+## flags.*.keywords
+
+Which keywords refer to this flag
+
+#### type
+
+non-empty list of string matching the pattern -[a-zA-Z0-9]|-(-[a-z0-9]*)
+
+
+#### default
+
+```nix
+{
+  flags.*.keywords = [];
+}
+```
+
+
+## flags.*.required
+
+Is the value required?
+
+#### type
+
+boolean
+
+
+#### default
+
+```nix
+{
+  flags.*.required = false;
+}
+```
+
+
+## flags.*.validator
+
+Command to run passing the input to validate the flag value
+
+#### type
+
+string
+
+
+#### default
+
+```nix
+{
+  flags.*.validator = "any";
+}
+```
+
+
+## flags.*.variable
+
+Variable to store the result
+
+#### type
+
+string matching the pattern [A-Z][A-Z_]*
+
+
+
+
+## name
+
+Name of the command shown on --help
+
+#### type
+
+string matching the pattern [a-zA-Z0-9_][a-zA-Z0-9_\-]*
+
+
+#### default
+
+```nix
+{
+  name = "example";
+}
+```
+
+
+## subcommands
+
+Subcommands has all the attributes of commands, even subcommands...
+
+#### type
+
+attribute set of submodule
+
+
+#### default
+
+```nix
+{
+  subcommands = {};
+}
+```
+
+
+## subcommands.&lt;name&gt;.name
+
+This is a recursive from command
+
+#### type
+
+string
+
+
+#### default
+
+```nix
+{
+  subcommands.<name>.name = "...";
+}
+```
+
+
+## target.bash.code
+
+Code output
+
+#### type
+
+strings concatenated with "\n"
+
+
+
+
+## target.bash.drv
+
+Package using the shell script version as a binary
+
+#### type
+
+package
+
+
+
+
+## target.bash.prelude
+
+Stuff that must be added before the argument parser
+
+#### type
+
+strings concatenated with "\n"
+
+
+#### default
+
+```nix
+{
+  target.bash.prelude = "";
+}
+```
+
+
+## target.bash.shebang
+
+Script shebang
+
+#### type
+
+string
+
+
+#### default
+
+```nix
+{
+  target.bash.shebang = "#!/usr/bin/env bash";
+}
+```
+
+
+## target.bash.validators
+
+Parameter validators
+
+#### type
+
+attribute set of string
+
+
+


### PR DESCRIPTION
Dynamic options docs

To build documentation as HTML
```bash
cd gh-pages
mdbook build
```

Configuration for github-pages not included

Good:
- Keep markdown and nix file in sync by running `nix develop build`

Bad:
- There is a workaround, for infinity recursion
- Add dependencies (devshell and devshell-files)

Other Options
- #4 
- #6